### PR TITLE
feat: add support for adding and deleting block field options

### DIFF
--- a/packages/backend/controllers/blockController.ts
+++ b/packages/backend/controllers/blockController.ts
@@ -39,7 +39,7 @@ export const blockController = () => ({
     const body = useJsonBody();
 
     const block = safeParse(UpdateBlockInput, body);
-    if (!block.success || !block.output.siteId || block.output.siteId !== session.siteId) {
+    if (!block.success || (block.output.siteId && block.output.siteId !== session.siteId)) {
       return response(422, { message: 'Error updating block', issues: block.issues });
     }
 

--- a/packages/backend/repositories/blockRepository.ts
+++ b/packages/backend/repositories/blockRepository.ts
@@ -96,6 +96,8 @@ export const blockRepository = {
 
     const updateBlockResponse = await dynamodbDocumentClient.send(updateBlockCommand);
 
+    console.log(JSON.stringify(updateBlockResponse.Attributes, null, 2));
+
     return safeParse(UpdateBlockOutput, updateBlockResponse.Attributes);
   },
   async deleteBlock(blockId: string, siteId: string) {

--- a/packages/frontend/components.d.ts
+++ b/packages/frontend/components.d.ts
@@ -8,11 +8,13 @@ export {}
 declare module 'vue' {
   export interface GlobalComponents {
     AddPageBlockModal: typeof import('./src/components/page/AddPageBlockModal.vue')['default']
+    AutoComplete: typeof import('primevue/autocomplete')['default']
     Avatar: typeof import('primevue/avatar')['default']
     Breadcrumb: typeof import('primevue/breadcrumb')['default']
     Button: typeof import('primevue/button')['default']
     Card: typeof import('primevue/card')['default']
     Chip: typeof import('primevue/chip')['default']
+    Chips: typeof import('primevue/chips')['default']
     Column: typeof import('primevue/column')['default']
     ConfirmBlockDeleteModal: typeof import('./src/components/block/ConfirmBlockDeleteModal.vue')['default']
     ConfirmPageDeleteModal: typeof import('./src/components/page/ConfirmPageDeleteModal.vue')['default']

--- a/packages/frontend/src/App.vue
+++ b/packages/frontend/src/App.vue
@@ -6,8 +6,7 @@
         template(#default)
           Component(:is="Component")
         template(#fallback)
-          .w-full.h-full.flex.items-center.justify-center
-            ProgressSpinner
+          ProgressSpinner.w-full.h-full.flex.items-center.justify-center
   Toast(:pt="toastPassThroughOptions")
 </template>
 

--- a/packages/frontend/src/layouts/Default.vue
+++ b/packages/frontend/src/layouts/Default.vue
@@ -130,7 +130,7 @@ const toggleUserMenu = (event: MouseEvent) => {
 const getMeResponse = await userStore.getMe();
 const getMeError = isAxiosError<GetMeError>(getMeResponse);
 
-if (getMeError && getMeResponse.status === 401) {
+if (getMeError && getMeResponse.response?.status === 401) {
   authStore.unsetToken();
   router.push({ name: 'Login' });
 }

--- a/packages/frontend/src/views/blocks/Blocks.vue
+++ b/packages/frontend/src/views/blocks/Blocks.vue
@@ -41,8 +41,7 @@
             template(#default)
               Component(:is="Component")
             template(#fallback)
-              .w-full.h-full.flex.items-center.justify-center
-                ProgressSpinner
+              ProgressSpinner.w-full.h-full.flex.items-center.justify-center
 </template>
 
 <script setup lang="ts">

--- a/packages/frontend/src/views/pages/page/PageBuilder.vue
+++ b/packages/frontend/src/views/pages/page/PageBuilder.vue
@@ -13,7 +13,7 @@
           i.text-gray-300.pi.pi-bars.ml-2.mr-4.cursor-move(data-pc-section="rowreordericon")
           span {{ data.block.label }}
         .flex-items-center
-          i.text-gray-400.pi.pi-pencil.mr-4.cursor-pointer(@click="data.modal = true")
+          i.text-gray-400.pi.pi-pencil.mr-4.cursor-pointer(v-if="data.SK" @click="data.modal = true")
           i.text-gray-400.pi.pi-trash.mr-2.cursor-pointer(@click="deleteBlock(index)")
         Sidebar.w-50vw(v-model:visible="data.modal" position="right")
   AddPageBlockModal(v-model="addPageBlockModal" @add="addBlock")

--- a/packages/schemas/block/entity.ts
+++ b/packages/schemas/block/entity.ts
@@ -19,7 +19,11 @@ export const BlockSchema = object({
     name: optional(string(), ''),
     label: optional(string(), ''),
     type: enum_(BlockFieldType),
-    options: optional(record(any())),
+    options: array(object({
+      name: string(),
+      label: string(),
+      value: array(string()),
+    })),
   })), []),
   updatedAt: optional(number(), DateTime.now().toSeconds()),
 });


### PR DESCRIPTION
The changes in this commit add functionality to add and delete options for block fields. 

Previously, the block fields did not have the ability to have multiple options. With this update, users can now add and delete options for each block field. 

This change improves the flexibility and customization options for block fields, allowing users to create more dynamic and interactive forms.